### PR TITLE
Adds ruby-version to gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 
 #coverage
 coverage
+
+#Ignore Rbenv.
+.ruby-version


### PR DESCRIPTION
## WHY

RBenv created a hidden ruby version file that we need to be ignored.
## HOW

Added ruby_version file to .gitignore.
## SIDE EFFECTS

None.
